### PR TITLE
Removed leftover dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1034,16 +1034,6 @@
         "ws": "3.1.0"
       }
     },
-    "eris-novum": {
-      "version": "git+https://git.dvguild.tk/briantanner/eris-novum.git#483fb5e1989a1d115a94e33893cb99874eec2c65",
-      "optional": true,
-      "requires": {
-        "eris": "git+https://github.com/abalabahaha/eris.git#39733fc6fadd8bf648bf713e5e5f990809e03849",
-        "redis": "2.7.1",
-        "tsubaki": "1.1.1",
-        "ytdl-core": "0.14.4"
-      }
-    },
     "erlpack": {
       "version": "github:hammerandchisel/erlpack#ad84c69355f03770a84d4bd8a20b981dd168fcf4",
       "requires": {


### PR DESCRIPTION
removed leftover dependency eris-novum from package-lock.json since it was deleted from package.json in https://github.com/rem-bot-industries/rem-v2/commit/365bd2ff1de01bfd687590943982356e72d4741f and prevented npm install from working.